### PR TITLE
Fix Education model missing property

### DIFF
--- a/TheJoshProject.Api/Models/Education.cs
+++ b/TheJoshProject.Api/Models/Education.cs
@@ -4,6 +4,7 @@ public class Education
 {
     public int EducationId { get; set; }
     required public string SchoolName { get; set; }
+    public string? SchoolLocation { get; set; }
     required public string Degree { get; set; }
     required public string Major { get; set; }
     required public DateTime StartDate { get; set; }


### PR DESCRIPTION
## Summary
- expose the `SchoolLocation` field in the Education model

## Testing
- `dotnet build TheJoshProject.sln`

------
https://chatgpt.com/codex/tasks/task_e_6862b448c73c83259d5f8c9066fca902