### PR TITLE
Update skill queries to include SkillId

### DIFF
--- a/TheJoshProject.Api/Services/SkillService.cs
+++ b/TheJoshProject.Api/Services/SkillService.cs
@@ -16,7 +16,7 @@ public class SkillService : ApiService, ISkillService
     public async Task<List<Skill>> GetSkillsByExperienceId(int experienceId)
     {
         var sql = @"
-            SELECT s.SkillName, s.SkillDescription FROM Skill s
+            SELECT s.SkillId, s.SkillName, s.SkillDescription FROM Skill s
             JOIN ExperienceSkill es ON es.SkillId = s.SkillId
             JOIN Experience ex ON ex.ExperienceId = es.ExperienceId
             JOIN Employer em ON em.EmployerId = ex.EmployerId
@@ -28,7 +28,7 @@ public class SkillService : ApiService, ISkillService
     public async Task<List<Skill>> GetSkillsByEmployerAndJob(string employerName, string jobTitle)
     {
         var sql = @"
-            SELECT s.SkillName, s.SkillDescription FROM Skill s
+            SELECT s.SkillId, s.SkillName, s.SkillDescription FROM Skill s
             JOIN ExperienceSkill es ON es.SkillId = s.SkillId
             JOIN Experience ex ON ex.ExperienceId = es.ExperienceId
             JOIN Employer em ON em.EmployerId = ex.EmployerId


### PR DESCRIPTION
## Summary
- ensure Skill objects include `SkillId` when retrieved by experience, employer, and job

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862b661c50c8325ba528a257751dc4d