### PR TITLE
Add README and refine SkillService tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# The Josh Project
+
+This repository contains an ASP.NET Core web API with accompanying database migrations and unit tests.
+
+## Requirements
+- [.NET 8 SDK](https://dotnet.microsoft.com/) installed
+- PostgreSQL database
+
+## Running Migrations and Seeds
+
+Database migrations and seed scripts are executed through the **TheJoshProject.Migrations** console project. Set the connection string in the `TheJoshProjectDefaultConnectionString` environment variable and run:
+
+```bash
+dotnet run --project TheJoshProject.Migrations
+```
+
+The scripts in `TheJoshProject.Migrations/Scripts` will be applied to the database.
+
+## Running Tests
+
+Execute the test suite using xUnit with:
+
+```bash
+dotnet test
+```
+
+## Running the Application
+
+Start the API by running:
+
+```bash
+dotnet run --project TheJoshProject.Api
+```
+
+The API will be available locally with Swagger UI enabled in development.

--- a/TheJoshProject.Tests/GlobalUsings.cs
+++ b/TheJoshProject.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/TheJoshProject.Tests/SkillServiceTests.cs
+++ b/TheJoshProject.Tests/SkillServiceTests.cs
@@ -1,0 +1,80 @@
+using Moq;
+using TheJoshProject.Api.Services;
+using TheJoshProject.Api.DataAccess;
+using TheJoshProject.Api.Models;
+
+namespace TheJoshProject.Tests;
+
+public class SkillServiceTests
+{
+    [Fact]
+    public async Task GetSkillsByExperienceId_ForwardsSqlAndReturnsResults()
+    {
+        // Arrange
+        var repoMock = new Mock<IRepository>();
+        var expected = new List<Skill>
+        {
+            new Skill { SkillId = 1, SkillName = "C#", SkillDescription = "desc" }
+        };
+
+        repoMock.Setup(r => r.GetAllDataAsync<Skill>(It.IsAny<string>(), It.IsAny<object?>()))
+            .ReturnsAsync(expected);
+
+        var service = new SkillService(repoMock.Object);
+
+        // Act
+        var result = await service.GetSkillsByExperienceId(5);
+
+        // Assert
+        Assert.Same(expected, result);
+
+        var expectedSql = @"
+            SELECT s.SkillName, s.SkillDescription FROM Skill s
+            JOIN ExperienceSkill es ON es.SkillId = s.SkillId
+            JOIN Experience ex ON ex.ExperienceId = es.ExperienceId
+            JOIN Employer em ON em.EmployerId = ex.EmployerId
+            WHERE ex.ExperienceId = @Id";
+
+        repoMock.Verify(r => r.GetAllDataAsync<Skill>(
+                It.Is<string>(s => s == expectedSql && s.Contains("SkillId")),
+                It.Is<object>(o =>
+                    o!.GetType().GetProperty("Id")?.GetValue(o) is int id && id == 5)
+            ), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetSkillsByEmployerAndJob_ForwardsSqlAndReturnsResults()
+    {
+        // Arrange
+        var repoMock = new Mock<IRepository>();
+        var expected = new List<Skill>
+        {
+            new Skill { SkillId = 1, SkillName = "SQL", SkillDescription = "db" }
+        };
+
+        repoMock.Setup(r => r.GetAllDataAsync<Skill>(It.IsAny<string>(), It.IsAny<object?>()))
+            .ReturnsAsync(expected);
+
+        var service = new SkillService(repoMock.Object);
+
+        // Act
+        var result = await service.GetSkillsByEmployerAndJob("ACME", "Developer");
+
+        // Assert
+        Assert.Same(expected, result);
+
+        var expectedSql = @"
+            SELECT s.SkillName, s.SkillDescription FROM Skill s
+            JOIN ExperienceSkill es ON es.SkillId = s.SkillId
+            JOIN Experience ex ON ex.ExperienceId = es.ExperienceId
+            JOIN Employer em ON em.EmployerId = ex.EmployerId
+            WHERE em.EmployerName = @EmployerName AND ex.JobTitle = @JobTitle";
+
+        repoMock.Verify(r => r.GetAllDataAsync<Skill>(
+                It.Is<string>(s => s == expectedSql && s.Contains("SkillId")),
+                It.Is<object>(o =>
+                    o!.GetType().GetProperty("EmployerName")?.GetValue(o) as string == "ACME" &&
+                    o.GetType().GetProperty("JobTitle")?.GetValue(o) as string == "Developer")
+            ), Times.Once);
+    }
+}

--- a/TheJoshProject.Tests/TheJoshProject.Tests.csproj
+++ b/TheJoshProject.Tests/TheJoshProject.Tests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\TheJoshProject.Api\TheJoshProject.Api.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/TheJoshProject.sln
+++ b/TheJoshProject.sln
@@ -7,6 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TheJoshProject.Api", "TheJo
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TheJoshProject.Migrations", "TheJoshProject.Migrations\TheJoshProject.Migrations.csproj", "{BD4E766B-9CF8-4F54-85C0-002968A7A008}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TheJoshProject.Tests", "TheJoshProject.Tests\TheJoshProject.Tests.csproj", "{3F845B31-1755-44B5-9FCD-B00FF1B93C72}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -24,5 +26,9 @@ Global
 		{BD4E766B-9CF8-4F54-85C0-002968A7A008}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BD4E766B-9CF8-4F54-85C0-002968A7A008}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BD4E766B-9CF8-4F54-85C0-002968A7A008}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3F845B31-1755-44B5-9FCD-B00FF1B93C72}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3F845B31-1755-44B5-9FCD-B00FF1B93C72}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3F845B31-1755-44B5-9FCD-B00FF1B93C72}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3F845B31-1755-44B5-9FCD-B00FF1B93C72}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
## Summary
- document running migrations, tests and API in README
- refine SkillService unit tests to verify repository calls
- fix newline in test GlobalUsings

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862b66cfa548325808db44be15e637b