### PR TITLE
Add service layer unit tests

### DIFF
--- a/TheJoshProject.Tests/EducationServiceTests.cs
+++ b/TheJoshProject.Tests/EducationServiceTests.cs
@@ -1,0 +1,60 @@
+using Moq;
+using TheJoshProject.Api.Services;
+using TheJoshProject.Api.Models;
+using TheJoshProject.Api.DataAccess.Repositories;
+
+namespace TheJoshProject.Tests;
+
+public class EducationServiceTests
+{
+    [Fact]
+    public async Task GetAllEducationAsync_ForwardsToRepository()
+    {
+        // Arrange
+        var repoMock = new Mock<IEducationRepository>();
+        var expected = new List<Education>
+        {
+            new Education
+            {
+                EducationId = 1,
+                SchoolName = "Test",
+                Degree = "B.S.",
+                Major = "CS",
+                StartDate = DateTime.UtcNow
+            }
+        };
+        repoMock.Setup(r => r.GetAllAsync()).ReturnsAsync(expected);
+        var service = new EducationService(repoMock.Object);
+
+        // Act
+        var result = await service.GetAllEducationAsync();
+
+        // Assert
+        Assert.Same(expected, result);
+        repoMock.Verify(r => r.GetAllAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetEducationByIdAsync_ForwardsToRepository()
+    {
+        // Arrange
+        var repoMock = new Mock<IEducationRepository>();
+        var expected = new Education
+        {
+            EducationId = 1,
+            SchoolName = "Test",
+            Degree = "B.S.",
+            Major = "CS",
+            StartDate = DateTime.UtcNow
+        };
+        repoMock.Setup(r => r.GetByIdAsync(It.IsAny<int>())).ReturnsAsync(expected);
+        var service = new EducationService(repoMock.Object);
+
+        // Act
+        var result = await service.GetEducationByIdAsync(3);
+
+        // Assert
+        Assert.Same(expected, result);
+        repoMock.Verify(r => r.GetByIdAsync(3), Times.Once);
+    }
+}

--- a/TheJoshProject.Tests/EmployerServiceTests.cs
+++ b/TheJoshProject.Tests/EmployerServiceTests.cs
@@ -1,0 +1,59 @@
+using Moq;
+using TheJoshProject.Api.Services;
+using TheJoshProject.Api.Models;
+using TheJoshProject.Api.DataAccess.Repositories;
+
+namespace TheJoshProject.Tests;
+
+public class EmployerServiceTests
+{
+    [Fact]
+    public async Task GetAllEmployers_ForwardsToRepository()
+    {
+        // Arrange
+        var repoMock = new Mock<IEmployerRepository>();
+        var expected = new List<Employer> { new Employer { EmployerId = 1, EmployerName = "ACME" } };
+        repoMock.Setup(r => r.GetAllAsync()).ReturnsAsync(expected);
+        var service = new EmployerService(repoMock.Object);
+
+        // Act
+        var result = await service.GetAllEmployers();
+
+        // Assert
+        Assert.Same(expected, result);
+        repoMock.Verify(r => r.GetAllAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetEmployer_ForwardsToRepository()
+    {
+        // Arrange
+        var repoMock = new Mock<IEmployerRepository>();
+        var expected = new Employer { EmployerId = 5, EmployerName = "Globex" };
+        repoMock.Setup(r => r.GetByIdAsync(It.IsAny<int>())).ReturnsAsync(expected);
+        var service = new EmployerService(repoMock.Object);
+
+        // Act
+        var result = await service.GetEmployer(8);
+
+        // Assert
+        Assert.Same(expected, result);
+        repoMock.Verify(r => r.GetByIdAsync(8), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetEmployerIdByName_ForwardsToRepository()
+    {
+        // Arrange
+        var repoMock = new Mock<IEmployerRepository>();
+        repoMock.Setup(r => r.GetIdByNameAsync(It.IsAny<string>())).ReturnsAsync(4);
+        var service = new EmployerService(repoMock.Object);
+
+        // Act
+        var result = await service.GetEmployerIdByName("Umbrella");
+
+        // Assert
+        Assert.Equal(4, result);
+        repoMock.Verify(r => r.GetIdByNameAsync("Umbrella"), Times.Once);
+    }
+}

--- a/TheJoshProject.Tests/ExperienceServiceTests.cs
+++ b/TheJoshProject.Tests/ExperienceServiceTests.cs
@@ -1,0 +1,74 @@
+using Moq;
+using TheJoshProject.Api.Services;
+using TheJoshProject.Api.Models;
+using TheJoshProject.Api.DataAccess.Repositories;
+
+namespace TheJoshProject.Tests;
+
+public class ExperienceServiceTests
+{
+    [Fact]
+    public async Task GetAllExperience_ForwardsToRepository()
+    {
+        // Arrange
+        var repoMock = new Mock<IExperienceRepository>();
+        var expected = new List<Experience>
+        {
+            new Experience
+            {
+                ExperienceId = 1,
+                EmployerName = "Example",
+                JobTitle = "Dev",
+                StartDate = DateTime.UtcNow
+            }
+        };
+        repoMock.Setup(r => r.GetAllAsync()).ReturnsAsync(expected);
+        var service = new ExperienceService(repoMock.Object);
+
+        // Act
+        var result = await service.GetAllExperience();
+
+        // Assert
+        Assert.Same(expected, result);
+        repoMock.Verify(r => r.GetAllAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetExperience_ForwardsToRepository()
+    {
+        // Arrange
+        var repoMock = new Mock<IExperienceRepository>();
+        var expected = new Experience
+        {
+            ExperienceId = 2,
+            EmployerName = "ACME",
+            JobTitle = "QA",
+            StartDate = DateTime.UtcNow
+        };
+        repoMock.Setup(r => r.GetByIdAsync(It.IsAny<int>())).ReturnsAsync(expected);
+        var service = new ExperienceService(repoMock.Object);
+
+        // Act
+        var result = await service.GetExperience(7);
+
+        // Assert
+        Assert.Same(expected, result);
+        repoMock.Verify(r => r.GetByIdAsync(7), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetExperienceIdByEmployerAndJob_ForwardsToRepository()
+    {
+        // Arrange
+        var repoMock = new Mock<IExperienceRepository>();
+        repoMock.Setup(r => r.GetIdByEmployerAndJobAsync(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(99);
+        var service = new ExperienceService(repoMock.Object);
+
+        // Act
+        var result = await service.GetExperienceIdByEmployerAndJob("ACME", "Dev");
+
+        // Assert
+        Assert.Equal(99, result);
+        repoMock.Verify(r => r.GetIdByEmployerAndJobAsync("ACME", "Dev"), Times.Once);
+    }
+}


### PR DESCRIPTION
## Summary
- cover EducationService, ExperienceService and EmployerService with tests
- verify interactions with repositories in each test

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_686411aa35dc832590ab2c6bd2c5dbf0