### PR TITLE
Add experience filtering endpoints

### DIFF
--- a/TheJoshProject.Api/Controllers/ExperienceController.cs
+++ b/TheJoshProject.Api/Controllers/ExperienceController.cs
@@ -57,8 +57,43 @@ public class ExperienceController : ControllerBase
     {
         var experience =  await _experienceService.GetExperience(id);
 
-        return experience == null 
+        return experience == null
             ? NotFound($"Experience with id {id} was not found")
             :  Ok(experience);
+    }
+
+    /// <summary>
+    /// Get experiences filtered by employer and/or date range
+    /// </summary>
+    /// <param name="employerName"></param>
+    /// <param name="startDate"></param>
+    /// <param name="endDate"></param>
+    /// <returns></returns>
+    /// <response code="200">Returns filtered experiences</response>
+    /// <response code="404">If filters are invalid or no data found</response>
+    /// <response code="500">If there is an error</response>
+    /// <remarks>
+    /// Sample request:
+    ///
+    ///     GET /api/experience/filter?employerName=ACME&startDate=2020-01-01&endDate=2021-01-01
+    ///
+    /// </remarks>
+    [HttpGet("filter")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public async Task<ActionResult<List<Experience>>> GetExperienceByFilter([
+        FromQuery] string? employerName,
+        [FromQuery] DateTime? startDate,
+        [FromQuery] DateTime? endDate)
+    {
+        if (startDate.HasValue && endDate.HasValue && startDate > endDate)
+        {
+            return NotFound("Invalid date range");
+        }
+
+        var results = await _experienceService.GetExperienceByFilters(employerName, startDate, endDate);
+
+        return results.Count == 0 ? NotFound("No experiences found") : Ok(results);
     }
 }

--- a/TheJoshProject.Api/DataAccess/Repositories/ExperienceRepository.cs
+++ b/TheJoshProject.Api/DataAccess/Repositories/ExperienceRepository.cs
@@ -2,6 +2,7 @@ namespace TheJoshProject.Api.DataAccess.Repositories;
 
 using TheJoshProject.Api.Models;
 using TheJoshProject.Api.DataAccess;
+using Dapper;
 
 public class ExperienceRepository : IExperienceRepository
 {
@@ -31,10 +32,43 @@ public class ExperienceRepository : IExperienceRepository
 
     public Task<int> GetIdByEmployerAndJobAsync(string employerName, string jobTitle)
     {
-        const string sql = @"            
+        const string sql = @"
             SELECT ex.ExperienceId FROM Experience ex
             JOIN Employer em ON em.EmployerId = ex.EmployerId
             WHERE em.EmployerName = @EmployerName AND ex.JobTitle = @JobTitle";
         return _repo.GetDataAsync<int>(sql, new { EmployerName = employerName, JobTitle = jobTitle });
+    }
+
+    public Task<List<Experience>> GetFilteredAsync(string? employerName, DateTime? startDate, DateTime? endDate)
+    {
+        var sql = @"
+            SELECT em.EmployerName, ex.* FROM Experience ex
+            JOIN Employer em ON em.EmployerId = ex.EmployerId";
+
+        var clauses = new List<string>();
+        var parms = new Dapper.DynamicParameters();
+
+        if (!string.IsNullOrWhiteSpace(employerName))
+        {
+            clauses.Add("em.EmployerName = @EmployerName");
+            parms.Add("EmployerName", employerName);
+        }
+        if (startDate.HasValue)
+        {
+            clauses.Add("ex.StartDate >= @StartDate");
+            parms.Add("StartDate", startDate.Value);
+        }
+        if (endDate.HasValue)
+        {
+            clauses.Add("(ex.EndDate <= @EndDate OR ex.EndDate IS NULL AND ex.StartDate <= @EndDate)");
+            parms.Add("EndDate", endDate.Value);
+        }
+
+        if (clauses.Count > 0)
+        {
+            sql += " WHERE " + string.Join(" AND ", clauses);
+        }
+
+        return _repo.GetAllDataAsync<Experience>(sql, parms);
     }
 }

--- a/TheJoshProject.Api/DataAccess/Repositories/IExperienceRepository.cs
+++ b/TheJoshProject.Api/DataAccess/Repositories/IExperienceRepository.cs
@@ -7,4 +7,5 @@ public interface IExperienceRepository
     Task<List<Experience>> GetAllAsync();
     Task<Experience?> GetByIdAsync(int id);
     Task<int> GetIdByEmployerAndJobAsync(string employerName, string jobTitle);
+    Task<List<Experience>> GetFilteredAsync(string? employerName, DateTime? startDate, DateTime? endDate);
 }

--- a/TheJoshProject.Api/Services/ExperienceService.cs
+++ b/TheJoshProject.Api/Services/ExperienceService.cs
@@ -27,4 +27,9 @@ public class ExperienceService : IExperienceService
         return await _experienceRepository.GetIdByEmployerAndJobAsync(employerName, jobTitle);
     }
 
+    public async Task<List<Experience>> GetExperienceByFilters(string? employerName, DateTime? startDate, DateTime? endDate)
+    {
+        return await _experienceRepository.GetFilteredAsync(employerName, startDate, endDate);
+    }
+
 }

--- a/TheJoshProject.Api/Services/IExperienceService.cs
+++ b/TheJoshProject.Api/Services/IExperienceService.cs
@@ -6,4 +6,5 @@ public interface IExperienceService
     Task<List<Experience>> GetAllExperience();
     Task<Experience?> GetExperience(int id);
     Task<int> GetExperienceIdByEmployerAndJob(string employerName, string jobTitle);
+    Task<List<Experience>> GetExperienceByFilters(string? employerName, DateTime? startDate, DateTime? endDate);
 }

--- a/TheJoshProject.Tests/ExperienceServiceTests.cs
+++ b/TheJoshProject.Tests/ExperienceServiceTests.cs
@@ -71,4 +71,30 @@ public class ExperienceServiceTests
         Assert.Equal(99, result);
         repoMock.Verify(r => r.GetIdByEmployerAndJobAsync("ACME", "Dev"), Times.Once);
     }
+
+    [Fact]
+    public async Task GetExperienceByFilters_ForwardsToRepository()
+    {
+        // Arrange
+        var repoMock = new Mock<IExperienceRepository>();
+        var expected = new List<Experience>
+        {
+            new Experience
+            {
+                ExperienceId = 10,
+                EmployerName = "ACME",
+                JobTitle = "Dev",
+                StartDate = DateTime.UtcNow
+            }
+        };
+        repoMock.Setup(r => r.GetFilteredAsync("ACME", null, null)).ReturnsAsync(expected);
+        var service = new ExperienceService(repoMock.Object);
+
+        // Act
+        var result = await service.GetExperienceByFilters("ACME", null, null);
+
+        // Assert
+        Assert.Same(expected, result);
+        repoMock.Verify(r => r.GetFilteredAsync("ACME", null, null), Times.Once);
+    }
 }


### PR DESCRIPTION
## Summary
- enable querying experiences by employer and dates in repository
- expose new filtering service method and controller endpoint
- update experience service tests

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6864231209e883259ce34db86b2cee69

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an endpoint to filter experiences by employer name and date range.
* **Bug Fixes**
  * Improved validation for date range filters to prevent invalid queries.
* **Documentation**
  * Enhanced endpoint documentation with parameter descriptions and sample usage.
* **Tests**
  * Introduced a new unit test to ensure correct filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->