### PR TITLE
Use env var for connection string

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,23 @@ This repository contains an ASP.NET Core web API with accompanying database migr
 - [.NET 8 SDK](https://dotnet.microsoft.com/) installed
 - PostgreSQL database
 
+## Configuration
+
+Both the API and migration projects read the database connection string from the
+`TheJoshProjectDefaultConnectionString` environment variable. For local
+development this value can be stored using the [.NET Secret Manager](https://learn.microsoft.com/aspnet/core/security/app-secrets):
+
+```bash
+dotnet user-secrets set "TheJoshProjectDefaultConnectionString" "Host=localhost;Database=ProjectJosh;Username=postgres;Password=yourpassword"
+```
+
+Alternatively export it in your shell or configure it in your deployment
+environment:
+
+```bash
+export TheJoshProjectDefaultConnectionString="Host=localhost;Database=ProjectJosh;Username=postgres;Password=yourpassword"
+```
+
 ## Running Migrations and Seeds
 
 Database migrations and seed scripts are executed through the **TheJoshProject.Migrations** console project. Set the connection string in the `TheJoshProjectDefaultConnectionString` environment variable and run:
@@ -32,4 +49,5 @@ Start the API by running:
 dotnet run --project TheJoshProject.Api
 ```
 
-The API will be available locally with Swagger UI enabled in development.
+Ensure `TheJoshProjectDefaultConnectionString` is set before launching. The API
+will be available locally with Swagger UI enabled in development.

--- a/TheJoshProject.Api/DataAccess/Repository.cs
+++ b/TheJoshProject.Api/DataAccess/Repository.cs
@@ -10,7 +10,16 @@ public class SqlRepository : IRepository
     public SqlRepository(IConfiguration configuration)
     {
         var connectionString = configuration.GetConnectionString("DefaultConnection");
-        Console.WriteLine($"connectionString: {connectionString}");
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            connectionString = configuration["TheJoshProjectDefaultConnectionString"];
+        }
+
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            throw new InvalidOperationException("Database connection string is not configured.");
+        }
+
         _db = new NpgsqlConnection(connectionString);
     }
 

--- a/TheJoshProject.Api/TheJoshProject.Api.csproj
+++ b/TheJoshProject.Api/TheJoshProject.Api.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <UserSecretsId>c921ada3-53e6-406d-9d80-b35afc7284ab</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TheJoshProject.Api/appsettings.json
+++ b/TheJoshProject.Api/appsettings.json
@@ -7,6 +7,6 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "DefaultConnection": "Server=localhost;Database=ProjectJosh;User Id=postgres;Password=dolphin;"
+    "DefaultConnection": ""
   }
 }


### PR DESCRIPTION
## Summary
- secure DB connection string by using env var fallback
- enable user secrets for easy local development
- add instructions about environment variable usage

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_686423b1d07c8325986388301f6731e9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README with detailed instructions on configuring the database connection string, including environment variable setup and usage of .NET Secret Manager.

* **New Features**
  * Enabled support for user secrets to securely manage sensitive configuration data during development.

* **Bug Fixes**
  * Improved validation and fallback logic for database connection string retrieval, ensuring the API fails clearly if the connection string is not configured.

* **Chores**
  * Cleared the default database connection string from the configuration file for enhanced security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->