### PR TITLE
Fix spacing for GetAll methods

### DIFF
--- a/TheJoshProject.Api/Controllers/EducationController.cs
+++ b/TheJoshProject.Api/Controllers/EducationController.cs
@@ -28,7 +28,7 @@ public class EducationController : ControllerBase
     [HttpGet("all")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public async Task<ActionResult<List<Education>>>GetAllEducationAsync()
+    public async Task<ActionResult<List<Education>>> GetAllEducationAsync()
     {
         var result = await _educationService.GetAllEducationAsync();
 

--- a/TheJoshProject.Api/Controllers/ExperienceController.cs
+++ b/TheJoshProject.Api/Controllers/ExperienceController.cs
@@ -28,7 +28,7 @@ public class ExperienceController : ControllerBase
     [HttpGet("all")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public async Task<ActionResult<List<Experience>>>GetAllExperiencesAsync()
+    public async Task<ActionResult<List<Experience>>> GetAllExperiencesAsync()
     {
         var result = await _experienceService.GetAllExperience();
 

--- a/TheJoshProject.Api/Controllers/SkillController.cs
+++ b/TheJoshProject.Api/Controllers/SkillController.cs
@@ -32,7 +32,7 @@ public class SkillController : ControllerBase
     [HttpGet("all")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public async Task<ActionResult<List<Skill>>>GetAllSkillsAsync()
+    public async Task<ActionResult<List<Skill>>> GetAllSkillsAsync()
     {
         return Ok(await _skillService.GetAllSkills());
     }


### PR DESCRIPTION
## Summary
- follow C# spacing conventions for async controller methods

## Testing
- `dotnet test --no-build` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686537b5231c8325937085c5d5449690

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved code formatting for method declarations to enhance readability. No changes to functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->